### PR TITLE
Support derive for enums, add ability to skip field type from is_type_tracked

### DIFF
--- a/gcmodule_derive/Cargo.toml
+++ b/gcmodule_derive/Cargo.toml
@@ -13,6 +13,8 @@ proc-macro = true
 [dependencies]
 quote = "1"
 syn = { version = "1", features = ["derive"] }
+proc-macro2 = "1.0.32"
+synstructure = "0.12"
 
 [dev-dependencies]
 gcmodule = { path = ".." }

--- a/gcmodule_derive/Cargo.toml
+++ b/gcmodule_derive/Cargo.toml
@@ -14,7 +14,6 @@ proc-macro = true
 quote = "1"
 syn = { version = "1", features = ["derive"] }
 proc-macro2 = "1.0.32"
-synstructure = "0.12"
 
 [dev-dependencies]
 gcmodule = { path = ".." }

--- a/gcmodule_derive/src/lib.rs
+++ b/gcmodule_derive/src/lib.rs
@@ -11,7 +11,7 @@
 //!     a: String,
 //!     b: Option<T>,
 //!
-//!     #[skip_trace] // ignore this field for Trace.
+//!     #[trace(skip)] // ignore this field for Trace.
 //!     c: MyType,
 //! }
 //!
@@ -19,68 +19,280 @@
 //! ```
 extern crate proc_macro;
 
-use quote::quote;
-use syn::Attribute;
-use synstructure::{decl_derive, AddBounds, BindStyle, Structure};
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{
+    parenthesized,
+    parse::{Parse, ParseStream},
+    parse_macro_input,
+    spanned::Spanned,
+    Attribute, Data, DeriveInput, Error, Field, Fields, Ident, Path, Result,
+};
 
-decl_derive!([Trace, attributes(skip_trace, ignore_tracking, force_tracking)] => derive_trace);
-
-fn has_attr(attrs: &[Attribute], attr: &str) -> bool {
-    attrs.iter().any(|a| a.path.is_ident(attr))
+mod kw {
+    syn::custom_keyword!(trace);
+    syn::custom_keyword!(skip);
+    syn::custom_keyword!(with);
+    syn::custom_keyword!(tracking);
+    syn::custom_keyword!(ignore);
+    syn::custom_keyword!(force);
 }
 
-fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
-    if has_attr(&s.ast().attrs, "skip_trace") {
-        s.filter(|_| false);
-        return s.bound_impl(
-            quote! {::gcmodule::Trace},
+enum TraceAttr {
+    Skip,
+    With(Path),
+    TrackingForce(bool),
+}
+impl TraceAttr {
+    fn force_is_type_tracked(&self) -> Option<TokenStream2> {
+        match self {
+            Self::TrackingForce(v) => Some(quote! {#v}),
+            Self::Skip => Some(quote! {false}),
+            Self::With(_) => Some(quote! {true}),
+        }
+    }
+}
+impl Parse for TraceAttr {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(kw::skip) {
+            input.parse::<kw::skip>()?;
+            Ok(Self::Skip)
+        } else if lookahead.peek(kw::tracking) {
+            input.parse::<kw::tracking>()?;
+            let content;
+            parenthesized!(content in input);
+            let lookahead = content.lookahead1();
+            if lookahead.peek(kw::ignore) {
+                content.parse::<kw::ignore>()?;
+                Ok(Self::TrackingForce(false))
+            } else if lookahead.peek(kw::force) {
+                content.parse::<kw::force>()?;
+                Ok(Self::TrackingForce(true))
+            } else {
+                Err(lookahead.error())
+            }
+        } else if lookahead.peek(kw::with) {
+            input.parse::<kw::with>()?;
+            let content;
+            parenthesized!(content in input);
+            Ok(Self::With(content.parse()?))
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
+fn parse_attr<A: Parse, I>(attrs: &[Attribute], ident: I) -> Result<Option<A>>
+where
+    Ident: PartialEq<I>,
+{
+    let attrs = attrs
+        .iter()
+        .filter(|a| a.path.is_ident(&ident))
+        .collect::<Vec<_>>();
+    if attrs.len() > 1 {
+        return Err(Error::new(
+            attrs[1].span(),
+            "this attribute may be specified only once",
+        ));
+    } else if attrs.is_empty() {
+        return Ok(None);
+    }
+    let attr = attrs[0];
+    let attr = attr.parse_args::<A>()?;
+
+    Ok(Some(attr))
+}
+
+/// Returns impl for (trace, is_type_tracked)
+fn derive_fields(
+    trace_attr: &Option<TraceAttr>,
+    fields: &Fields,
+) -> Result<(TokenStream2, TokenStream2)> {
+    fn inner<'a>(names: &[Ident], fields: Vec<&Field>) -> Result<(TokenStream2, TokenStream2)> {
+        let attrs = fields
+            .iter()
+            .map(|f| parse_attr::<TraceAttr, _>(&f.attrs, "trace"))
+            .collect::<Result<Vec<_>>>()?;
+
+        let trace = names.iter().zip(attrs.iter()).filter_map(|(name, attr)| {
+            match attr {
+                Some(TraceAttr::Skip) => return None,
+                Some(TraceAttr::With(w)) => return Some(quote! {#w(#name, tracer)}),
+                _ => {}
+            }
+            Some(quote! {
+                ::gcmodule::Trace::trace(#name, tracer)
+            })
+        });
+        let is_type_tracked = fields.iter().zip(attrs.iter()).filter_map(|(field, attr)| {
+            match attr {
+                Some(TraceAttr::Skip | TraceAttr::TrackingForce(false)) => return None,
+                Some(TraceAttr::With(_) | TraceAttr::TrackingForce(true)) => {
+                    return Some(quote! {true})
+                }
+                _ => {}
+            }
+            let ty = &field.ty;
+            Some(quote! {
+                <#ty as ::gcmodule::Trace>::is_type_tracked()
+            })
+        });
+
+        let trace = quote! {
+            #(#trace;)*
+        };
+
+        Ok((
+            trace,
             quote! {
-                fn trace(&self, _tracer: &mut ::gcmodule::Tracer) {}
+                #(if #is_type_tracked {return true;})*
+            },
+        ))
+    }
+    match fields {
+        Fields::Named(named) => {
+            if matches!(trace_attr, Some(TraceAttr::Skip)) {
+                return Ok((
+                    quote! {
+                        {...} => {}
+                    },
+                    quote! {},
+                ));
+            }
+            let force_is_type_tracked = trace_attr.as_ref().and_then(|a| a.force_is_type_tracked());
+
+            let names = named
+                .named
+                .iter()
+                .map(|i| i.ident.clone().unwrap())
+                .collect::<Vec<_>>();
+            let (trace, is_type_tracked) = inner(&names, named.named.iter().collect())?;
+            let is_type_tracked = force_is_type_tracked.unwrap_or(is_type_tracked);
+
+            Ok((
+                quote! {
+                    {#(#names),*} => {#trace}
+                },
+                is_type_tracked,
+            ))
+        }
+        Fields::Unnamed(unnamed) => {
+            if matches!(trace_attr, Some(TraceAttr::Skip)) {
+                return Ok((quote! {(...) => {}}, quote! {}));
+            }
+            let force_is_type_tracked = trace_attr.as_ref().and_then(|a| a.force_is_type_tracked());
+
+            let names = (0..unnamed.unnamed.len())
+                .map(|i| format_ident!("field_{}", i))
+                .collect::<Vec<_>>();
+            let (trace, is_type_tracked) = inner(&names, unnamed.unnamed.iter().collect())?;
+            let is_type_tracked = force_is_type_tracked.unwrap_or(is_type_tracked);
+
+            Ok((
+                quote! {
+                    (#(#names,)*) => {#trace}
+                },
+                is_type_tracked,
+            ))
+        }
+        Fields::Unit => Ok((
+            quote! {
+                => {}
+            },
+            quote! {},
+        )),
+    }
+}
+
+fn derive_trace(input: DeriveInput) -> Result<TokenStream2> {
+    let trace_attr = parse_attr::<TraceAttr, _>(&input.attrs, "trace")?;
+    if matches!(trace_attr, Some(TraceAttr::With(_))) {
+        return Err(Error::new(input.span(), "implement Trace instead"));
+    }
+    let ident = &input.ident;
+    let (impl_generics, type_generics, where_clause) = input.generics.split_for_impl();
+    if matches!(trace_attr, Some(TraceAttr::Skip)) {
+        return Ok(quote! {
+            impl #impl_generics ::gcmodule::Trace for #ident #type_generics #where_clause {
+                fn trace(&self, _tracer: &mut ::gcmodule::Tracer) {
+                }
                 fn is_type_tracked() -> bool {
                     false
                 }
-            },
-        );
-    }
-    let force_tracking = has_attr(&s.ast().attrs, "force_tracking");
-
-    s.filter_variants(|f| !has_attr(f.ast().attrs, "skip_trace"));
-    s.filter(|f| !has_attr(&f.ast().attrs, "skip_trace"));
-    s.add_bounds(AddBounds::Fields);
-    s.bind_with(|_| BindStyle::Ref);
-
-    let trace_body = s.each(|bi| quote!(::gcmodule::Trace::trace(#bi, tracer)));
-
-    let is_type_tracked_body = if force_tracking {
-        quote! {
-            true
-        }
-    } else {
-        s.filter(|f| !has_attr(&f.ast().attrs, "ignore_tracking"));
-        let ty = s
-            .variants()
-            .iter()
-            .flat_map(|v| v.bindings().iter())
-            .map(|bi| &bi.ast().ty);
-        quote! {
-            #(
-            if <#ty>::is_type_tracked() {
-                return true;
             }
-            )*
-            false
-        }
-    };
+        });
+    }
+    let force_is_type_tracked = trace_attr.and_then(|a| a.force_is_type_tracked());
+    let (trace, is_type_tracked) = match &input.data {
+        Data::Struct(s) => {
+            let (trace, is_type_tracked) = derive_fields(&None, &s.fields)?;
 
-    s.bound_impl(
-        quote! {::gcmodule::Trace},
-        quote! {
+            (
+                quote! {
+                    Self#trace
+                },
+                quote! {
+                    #is_type_tracked
+                    false
+                },
+            )
+        }
+        Data::Enum(e) if e.variants.is_empty() => (quote! {_=>unreachable!()}, quote! {false}),
+        Data::Enum(e) => {
+            let variants = e
+                .variants
+                .iter()
+                .map(|v| {
+                    let name = &v.ident;
+                    let attr = parse_attr::<TraceAttr, _>(&v.attrs, "trace")?;
+                    let impls = derive_fields(&attr, &v.fields)?;
+                    Ok((name, impls)) as Result<_>
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            let trace = variants.iter().map(|(name, (trace, _))| {
+                quote! {
+                    Self::#name #trace
+                }
+            });
+            let is_type_tracked = variants.iter().map(|(_, (_, v))| v);
+
+            (
+                quote! {
+                    #(#trace),*
+                },
+                quote! {
+                    #(#is_type_tracked)*
+                    false
+                },
+            )
+        }
+
+        Data::Union(_) => return Err(Error::new(input.span(), "union is not supported")),
+    };
+    let is_type_tracked = force_is_type_tracked.unwrap_or(is_type_tracked);
+    Ok(quote! {
+        impl #impl_generics ::gcmodule::Trace for #ident #type_generics #where_clause {
             fn trace(&self, tracer: &mut ::gcmodule::Tracer) {
-                match *self { #trace_body }
+                match self {
+                    #trace
+                }
             }
             fn is_type_tracked() -> bool {
-                #is_type_tracked_body
+                #is_type_tracked
             }
-        },
-    )
+        }
+    })
+}
+
+#[proc_macro_derive(Trace, attributes(trace))]
+pub fn derive_trace_real(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match derive_trace(input) {
+        Ok(v) => v.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
 }

--- a/gcmodule_derive/tests/trace.rs
+++ b/gcmodule_derive/tests/trace.rs
@@ -42,7 +42,7 @@ fn test_type_parameters() {
 fn test_field_skip() {
     #[derive(DeriveTrace)]
     struct S2 {
-        #[trace(skip)]
+        #[skip_trace]
         _a: Option<Box<dyn Trace>>,
         _b: (u32, u64),
     }
@@ -52,7 +52,7 @@ fn test_field_skip() {
 #[test]
 fn test_container_skip() {
     #[derive(DeriveTrace)]
-    #[trace(skip)]
+    #[skip_trace]
     struct S0 {
         _a: Option<Box<dyn Trace>>,
         _b: (u32, u64),
@@ -60,19 +60,44 @@ fn test_container_skip() {
     assert!(!S0::is_type_tracked());
 
     #[derive(DeriveTrace)]
-    #[trace(skip)]
+    #[skip_trace]
     union U0 {
         _b: (u32, u64),
     }
     assert!(!U0::is_type_tracked());
 
     #[derive(DeriveTrace)]
-    #[trace(skip)]
+    #[skip_trace]
     enum E0 {
         _A(Option<Box<dyn Trace>>),
         _B(u32, u64),
     }
     assert!(!E0::is_type_tracked());
+}
+
+#[test]
+fn test_recursive_struct() {
+    #[derive(DeriveTrace)]
+    struct A {
+        b: Box<dyn Trace>,
+        #[ignore_tracking]
+        a: Box<A>,
+    }
+    assert!(A::is_type_tracked());
+
+    #[derive(DeriveTrace)]
+    struct B {
+        #[ignore_tracking]
+        b: Box<B>,
+    }
+    assert!(!B::is_type_tracked());
+
+    #[derive(DeriveTrace)]
+    #[force_tracking]
+    struct C {
+        c: (Box<C>, Box<dyn Trace>),
+    }
+    assert!(C::is_type_tracked());
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@
 //! struct Foo {
 //!     field: String,
 //!
-//!     #[skip_trace]
+//!     #[trace(skip)]
 //!     alien: AlienStruct, // Field skipped in Trace implementation.
 //! }
 //! ```
@@ -299,7 +299,7 @@ pub use sync::{collect::ThreadedObjectSpace, ThreadedCc, ThreadedCcRef};
 ///     a: S1,
 ///     b: Option<S2<T, u8>>,
 ///
-///     #[skip_trace]
+///     #[trace(skip)]
 ///     c: AlienStruct,  // c is not tracked by the collector.
 /// }
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@
 //! assert_eq!(gcmodule::count_thread_tracked(), 1);
 //! ```
 //!
-//! The `#[trace(skip)]` attribute can be used to skip tracking specified fields
+//! The `#[skip_trace]` attribute can be used to skip tracking specified fields
 //! in a structure.
 //!
 //! ```
@@ -143,7 +143,7 @@
 //! struct Foo {
 //!     field: String,
 //!
-//!     #[trace(skip)]
+//!     #[skip_trace]
 //!     alien: AlienStruct, // Field skipped in Trace implementation.
 //! }
 //! ```
@@ -299,7 +299,7 @@ pub use sync::{collect::ThreadedObjectSpace, ThreadedCc, ThreadedCcRef};
 ///     a: S1,
 ///     b: Option<S2<T, u8>>,
 ///
-///     #[trace(skip)]
+///     #[skip_trace]
 ///     c: AlienStruct,  // c is not tracked by the collector.
 /// }
 ///


### PR DESCRIPTION
is_type_tracked causes issue in this case:
```rs
#[derive(Trace)]
struct A {
    a: Box<A>,
}
```

Because it expands to
```rs
impl Trace for A {
    fn is_type_tracked() -> bool {
        A::is_type_tracked()
    }
}
```

It causes stack overflow

To address this issue, i added additional filter for derive: `ignore_tracking`:
```rs
struct A {
    #[ignore_tracking]
    a: Box<A>,
}
```