### PR TITLE
Ability to disable garbage collection on exit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,9 @@ mod trace;
 mod trace_impls;
 
 pub use cc::{Cc, RawCc, RawWeak, Weak};
-pub use collect::{collect_thread_cycles, count_thread_tracked, ObjectSpace};
+pub use collect::{
+    collect_thread_cycles, count_thread_tracked, set_thread_collect_on_drop, ObjectSpace,
+};
 pub use trace::{Trace, Tracer};
 
 #[cfg(feature = "sync")]


### PR DESCRIPTION
While this toggle isn't useful in general (because you can always call `forget(space)`), it is useful in thread-local case, because destructors for TLS entries are ran, and this isn't needed in case of CLI apps, where it delays shutdown