### PR TITLE
Ability to leak all objects from ObjectSpace

### DIFF
--- a/src/collect.rs
+++ b/src/collect.rs
@@ -165,6 +165,11 @@ impl ObjectSpace {
         Cc::new_in_space(value, self)
     }
 
+    /// Leak all objects allocated in this space
+    pub fn leak(&self) {
+        *self.list.borrow_mut() = new_gc_list();
+    }
+
     // TODO: Consider implementing "merge" or method to collect multiple spaces
     // together, to make it easier to support generational collection.
 }
@@ -246,6 +251,11 @@ pub fn count_thread_tracked() -> usize {
 }
 
 thread_local!(pub(crate) static THREAD_OBJECT_SPACE: ObjectSpace = ObjectSpace::default());
+
+/// Acquire reference to thread-local global object space
+pub fn with_thread_object_space<R>(handler: impl FnOnce(&ObjectSpace) -> R) -> R {
+    THREAD_OBJECT_SPACE.with(handler)
+}
 
 /// Create an empty linked list with a dummy GcHeader.
 pub(crate) fn new_gc_list() -> Pin<Box<GcHeader>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,9 @@ mod trace;
 mod trace_impls;
 
 pub use cc::{Cc, RawCc, RawWeak, Weak};
-pub use collect::{collect_thread_cycles, count_thread_tracked, ObjectSpace};
+pub use collect::{
+    collect_thread_cycles, count_thread_tracked, with_thread_object_space, ObjectSpace,
+};
 pub use trace::{Trace, Tracer};
 
 #[cfg(feature = "sync")]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
-use crate::debug;
 use crate::testutil::test_small_graph;
 use crate::{collect, Cc, Trace, Tracer};
+use crate::{debug, with_thread_object_space};
 use std::cell::Cell;
 use std::cell::RefCell;
 use std::ops::Deref;
@@ -507,6 +507,17 @@ fn test_trace_impl_double_visits() {
         });
         assert!(message.contains("bug: accessing a dropped CcBox detected"));
     }
+}
+
+#[test]
+#[ignore = "causes memory leak, thus causing valgrind to error"]
+fn leak() {
+    let a = Cc::new(1);
+    let b = Cc::new((a.clone(), 1));
+    with_thread_object_space(|s| s.leak());
+    assert_eq!(crate::count_thread_tracked(), 0);
+    assert_eq!(*a, 1);
+    let _ = b;
 }
 
 #[cfg(not(miri))]


### PR DESCRIPTION
While this isn't useful in general (because you can always call forget(space)), it is useful in thread-local case, because destructors for TLS entries are ran, and this isn't needed in case of CLI apps, where it delays shutdown